### PR TITLE
Switch to docker-asciidoctor image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,40 @@
 FROM asciidoctor/docker-asciidoctor:1.60@sha256:0c8df5a7688303b70fb8db3bec25c19503d7232d38b61cfaef0c943e1722c018
 
+RUN apk add \
+      chromium \
+      nss \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      nodejs \
+      npm \
+      bash
+
+RUN mkdir /mermaid
+
+WORKDIR /mermaid
+
+COPY mermaid-package.json package.json
+COPY mermaid-package-lock.json package-lock.json
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# --silent because otherwise we get warnings about the tiny package.json we're
+# using. We don't really have a named package here, we just want to specify
+# some dependencies.
+RUN npm install --silent @mermaid-js/mermaid-cli
+
+# Add user so we don't need --no-sandbox.
+RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+    && chown -R pptruser:pptruser /mermaid
+
+RUN /bin/bash -c "echo '{\"args\":[\"--no-sandbox\"]}' > /mermaid/puppeteer-config.json"
+
+ENV PATH /mermaid/node_modules/.bin:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,4 @@
-FROM ruby:2-alpine
-
-RUN gem install asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
-
-RUN apk add --no-cache \
-      chromium \
-      nss \
-      freetype \
-      freetype-dev \
-      harfbuzz \
-      ca-certificates \
-      ttf-freefont \
-      nodejs \
-      npm \
-      openjdk11 \
-      graphviz \
-      bash
-
-RUN mkdir /mermaid
-
-WORKDIR /mermaid
-
-COPY mermaid-package.json package.json
-COPY mermaid-package-lock.json package-lock.json
-
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
-
-
-# --silent because otherwise we get warnings about the tiny package.json we're
-# using. We don't really have a named package here, we just want to specify
-# some dependencies.
-RUN npm install --silent @mermaid-js/mermaid-cli
-
-# Add user so we don't need --no-sandbox.
-RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
-    && chown -R pptruser:pptruser /mermaid
-
-RUN /bin/bash -c "echo '{\"args\":[\"--no-sandbox\"]}' > /mermaid/puppeteer-config.json"
-
-ENV PATH /mermaid/node_modules/.bin:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+FROM asciidoctor/docker-asciidoctor:1.60@sha256:0c8df5a7688303b70fb8db3bec25c19503d7232d38b61cfaef0c943e1722c018
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/mermaid-package-lock.json
+++ b/mermaid-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mermaid-js/mermaid-cli": "9.2.2"
+        "@mermaid-js/mermaid-cli": "10.6.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -58,20 +58,19 @@
       }
     },
     "node_modules/@mermaid-js/mermaid-cli": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-9.2.2.tgz",
-      "integrity": "sha512-Bb0eKH9zA7AKcnjfTeCAVBsZv53ZwgBeIMM/kEqht8+9Fw29nxflGgq1vQOZoLQYsHZzIhB6cWTthx7ahNOi+g==",
-      "license": "MIT",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-10.6.1.tgz",
+      "integrity": "sha512-OH2uOXW3/GBaMGagVF7Fzu/9TJrGge+Bu/+Tm8OyIaRBaKa2NN+3SggJOmr5s51oTPaGKu/X1XBDoauvtlXAPg==",
       "dependencies": {
         "chalk": "^5.0.1",
-        "commander": "^9.0.0",
+        "commander": "^10.0.0",
         "puppeteer": "^19.0.0"
       },
       "bin": {
         "mmdc": "src/cli.js"
       },
       "engines": {
-        "node": ">=14.1.0"
+        "node": "^14.13 || >=16.0"
       }
     },
     "node_modules/@types/node": {
@@ -244,12 +243,11 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
-      "license": "MIT",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=14"
       }
     },
     "node_modules/concat-map": {
@@ -913,12 +911,12 @@
       }
     },
     "@mermaid-js/mermaid-cli": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-9.2.2.tgz",
-      "integrity": "sha512-Bb0eKH9zA7AKcnjfTeCAVBsZv53ZwgBeIMM/kEqht8+9Fw29nxflGgq1vQOZoLQYsHZzIhB6cWTthx7ahNOi+g==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-10.6.1.tgz",
+      "integrity": "sha512-OH2uOXW3/GBaMGagVF7Fzu/9TJrGge+Bu/+Tm8OyIaRBaKa2NN+3SggJOmr5s51oTPaGKu/X1XBDoauvtlXAPg==",
       "requires": {
         "chalk": "^5.0.1",
-        "commander": "^9.0.0",
+        "commander": "^10.0.0",
         "puppeteer": "^19.0.0"
       }
     },
@@ -1030,9 +1028,9 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/mermaid-package.json
+++ b/mermaid-package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mermaid-js/mermaid-cli": "9.2.2"
+    "@mermaid-js/mermaid-cli": "10.6.1"
   }
 }


### PR DESCRIPTION
Part of LeastAuthority/it-ops#406

Use the official docker image to save 5 minutes of built time on average.

REM: this changes also updates `mermaid-cli` from v9.2.2 to v10.6.1.