### PR TITLE
Switch to docker-asciidoctor image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM ruby:2-alpine
+FROM asciidoctor/docker-asciidoctor:1.60@sha256:0c8df5a7688303b70fb8db3bec25c19503d7232d38b61cfaef0c943e1722c018
 
-RUN gem install asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
-
-RUN apk add --no-cache \
+RUN apk add \
       chromium \
       nss \
       freetype \


### PR DESCRIPTION
Part of LeastAuthority/it-ops#406

Use the official docker-asciidoctor image to save 5 minutes of built time on average.