### PR TITLE
Trigger jobs on main branch too

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: Action test
   
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   test-html:


### PR DESCRIPTION
Part of LeastAuthority/it-ops#406

Default branch being `main`, we need to trigger the jobs on this name too.