### PR TITLE
Bump mermaid-cli and its dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: Action test
   
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   test-html:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM ruby:2-alpine
+FROM asciidoctor/docker-asciidoctor:1.60@sha256:0c8df5a7688303b70fb8db3bec25c19503d7232d38b61cfaef0c943e1722c018
 
-RUN gem install asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
-
-RUN apk add --no-cache \
+RUN apk add \
       chromium \
       nss \
       freetype \


### PR DESCRIPTION
Part of LeastAuthority/it-ops#406

Updates `mermaid-cli` from v9.2.2 to v10.6.1.