### PR TITLE
Fix GitHub output following deprecation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         TEST_COMMAND: |-
           asciidoctor -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
-          ::set-output name=asciidoctor-artifacts::asciidoc-out
+          asciidoctor-artifacts=asciidoc-out
   test-html-args:
     runs-on: ubuntu-latest
 
@@ -36,7 +36,7 @@ jobs:
         TEST_COMMAND: |-
           asciidoctor -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge -a revdate=`date +%Y-%m-%d` --failure-level=ERROR test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
-          ::set-output name=asciidoctor-artifacts::asciidoc-out
+          asciidoctor-artifacts=asciidoc-out
   test-pdf:
     runs-on: ubuntu-latest
 
@@ -51,7 +51,7 @@ jobs:
         TEST_COMMAND: |-
           asciidoctor-pdf -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
-          ::set-output name=asciidoctor-artifacts::asciidoc-out
+          asciidoctor-artifacts=asciidoc-out
   test-pdf-args:
     runs-on: ubuntu-latest
 
@@ -67,4 +67,4 @@ jobs:
         TEST_COMMAND: |-
           asciidoctor-pdf -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge -a revdate=`date +%Y-%m-%d` --failure-level=ERROR test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
-          ::set-output name=asciidoctor-artifacts::asciidoc-out
+          asciidoctor-artifacts=asciidoc-out

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,12 +46,12 @@ mkdir $GITHUB_WORKSPACE/asciidoc-out
 eval $COMMAND
 
 FILES=$(echo $GITHUB_WORKSPACE/asciidoc-out/**/*)
-OUTPUT="::set-output name=asciidoctor-artifacts::asciidoc-out"
+OUTPUT="asciidoctor-artifacts=asciidoc-out"
 echo "Generated files $FILES"
 
 if [[ -z $TEST_COMMAND && -z $TEST_OUTPUT ]]; then
   echo "Output:"
-  echo "${OUTPUT}"
+  echo "${OUTPUT}" >> $GITHUB_OUTPUT
   echo "Output ${OUTPUT}"
 elif [[ "${COMMAND}" != "${TEST_COMMAND}" ]]; then
   printf "Ran unexpected command:\n" >&2
@@ -65,6 +65,6 @@ else
   echo "Command equals test expectations:"
   echo "${TEST_COMMAND}"
   echo "And output equals test expectations:"
-  echo "${TEST_OUTPUT}"
+  echo "${TEST_OUTPUT}" >> $GITHUB_OUTPUT
   exit 0
 fi


### PR DESCRIPTION
This should avoid the warnings:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
